### PR TITLE
Add plugin list in settings page.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,8 @@ export default class Galore extends Plugin {
 					repo: await parseRepoURL("https://github.com/dylanpizzo/obsidian-plugins-galore"),
 					version: this.manifest.version,
 				}
-			}
+			},
+			history: []
 		}, await this.loadData());
 	}
 

--- a/src/ui/addModalClearHistory.ts
+++ b/src/ui/addModalClearHistory.ts
@@ -1,0 +1,47 @@
+import { Modal, Setting, Notice } from 'obsidian';
+
+export default class GaloreAddModalClearHistory extends Modal {
+	onSubmit: (isConfirmed: boolean) => void;
+
+	constructor(onSubmit: (isConfirmed: boolean) => void) {
+		super(app);
+		this.onSubmit = onSubmit;
+	}
+
+	onOpen(): void {
+		const {contentEl} = this;
+
+		contentEl.empty();
+
+		contentEl.createEl("h2", {text: "Plugins Galore: Clear History"})
+
+		new Setting(contentEl)
+			.setName(createFragment(descEl => {
+				descEl.createDiv({}, div => {
+					div.appendText("This will remove all history entries.")
+					div.createEl("br")
+					div.createEl("b", { text: "Are you sure?" })
+				})
+			}))
+			.addButton(button => button
+				.setButtonText("Confirm")
+				.setWarning()
+				.onClick(() => {
+					this.close();
+					this.onSubmit(true);
+				})
+			)
+			.addButton(button => button
+				.setButtonText("Cancel")
+				.onClick(() => {
+					this.close();
+					this.onSubmit(false);
+				})
+			)
+	}
+
+	onClose() {
+		const {contentEl} = this;
+		contentEl.empty();
+	}
+}

--- a/src/ui/settingsPage.ts
+++ b/src/ui/settingsPage.ts
@@ -1,11 +1,13 @@
 import { App, Plugin, Notice, PluginSettingTab, Setting } from 'obsidian';
 import Galore from '../main';
-import { getGalorePlugins } from '../util/pluginActions';
+import { getGalorePlugins, clearHistory, removeFromHistory } from '../util/pluginActions';
 import GaloreUpdateModal from './updateModal';
 import GaloreAddModal from './addModal';
+import GaloreAddModalClearHistory from './addModalClearHistory';
 
 export default class GaloreSettingTab extends PluginSettingTab {
 	plugin: Galore;
+	doOpenHistoryDetails = false;
 	
 	constructor(plugin: Galore) {
 		super(app, plugin);
@@ -50,5 +52,115 @@ export default class GaloreSettingTab extends PluginSettingTab {
 					}
 				})
 			)
+
+		new Setting(containerEl)
+			.setName("Plugin List")
+			.setDesc(createFragment(descEl => {
+				descEl.createDiv({}, div => {
+					div.appendText("This shows a list of currently and previously installed Galore plugins.")
+					div.createEl("br")
+					div.createEl("b", { text: "Installed: " })
+					div.appendText("Plugins that installed via Plugin Galore.")
+					div.createEl("br")
+					div.createEl("b", { text: "History: " })
+					div.appendText("Plugins that are not currently installed, but were once installed via Plugin Galore.")
+				})
+			}));
+
+		// Installed list
+		const collapsibleInstalledPlugins = containerEl.createEl('details');
+		const summaryInstalledPlugins = collapsibleInstalledPlugins.createEl('summary', { text: "Installed" });
+		new Setting(summaryInstalledPlugins)
+			.setHeading();
+
+		(async () => {
+			const galorePlugins = await getGalorePlugins(this.plugin);
+			const galorePluginsExceptGalore = galorePlugins.filter((x) => x.manifest.id != "plugins-galore");
+
+			galorePluginsExceptGalore.forEach((plugin) => {
+				new Setting(collapsibleInstalledPlugins)
+					.setName(plugin.manifest.name)
+					.setDesc(createFragment((descEl) => {
+						descEl.createDiv({}, (div) => {
+							div.appendText("Version: " + plugin.manifest.version)
+							div.createEl("br")
+							div.appendText("By " + plugin.manifest.author)
+							div.createEl("br")
+							div.appendText(plugin.manifest.description)
+						})
+					}))
+			})
+		})();
+
+		// History list
+		const collapsibleHistoryPlugins = containerEl.createEl('details');
+		if (this.doOpenHistoryDetails) {
+			collapsibleHistoryPlugins.open = true;
+			this.doOpenHistoryDetails = false;
+		}
+
+		new Setting(collapsibleHistoryPlugins)
+			.addButton( button => button
+					.setButtonText("Clear history")
+					.setTooltip("Remove all history entries")
+					.setWarning()
+					.onClick( () => {
+						new GaloreAddModalClearHistory(async isConfirmed => {
+							if (isConfirmed) {
+								await clearHistory(this.plugin);
+								new Notice(`History cleared.`);
+								this.doOpenHistoryDetails = true;
+								this.display();
+							}
+						}).open();
+					} )
+			);
+		const summaryHistoryPlugins = collapsibleHistoryPlugins.createEl('summary', { text: "History" });
+		new Setting(summaryHistoryPlugins)
+			.setHeading();
+
+		const galoreHistory = this.plugin.galoreData.history;
+		this.sortHistory(galoreHistory);
+		galoreHistory.forEach( (obj: any) => {
+			const key = Object.keys(obj)[0];
+			new Setting(collapsibleHistoryPlugins)
+				.setName(key)
+				.setDesc(createFragment((descEl) => {
+					descEl.createDiv({}, (div) => {
+						div.appendText("Version: " + obj[key].version)
+						div.createEl("br")
+						div.appendText("By " + obj[key].repo.owner)
+						div.createEl("br")
+						div.appendText("In history since: " + obj[key].timestamp)
+					})
+				}))
+				.addExtraButton( button => button
+						.setIcon("trash")
+						.setTooltip("Remove this entry from history")
+						.onClick( async () => {
+							const idx = galoreHistory.indexOf(obj);
+							await removeFromHistory(this.plugin, idx);
+							new Notice(`Removed from history: ` + key);
+							this.doOpenHistoryDetails = true;
+							this.display();
+						})
+				);
+		})
+	}
+
+	// Sort history by timestamp (in ascending order)
+	sortHistory(history: Array<Object>) {
+		history.sort( (a: any, b: any) => {
+			const keyA = Object.keys(a)[0];
+			const keyB = Object.keys(b)[0];
+
+			if (a[keyA].timestamp > b[keyB].timestamp)
+				return 1;
+
+			if (a[keyA].timestamp < b[keyB].timestamp)
+				return -1;
+
+			return 0;
+		});
 	}
 }


### PR DESCRIPTION
Inspired by #3 I added two collapsible lists in the settings page:
`Installed` - shows all plugins installed via Galore.
`History` - shows missing plugins that were previously installed via Galore.
Entries in History can be removed individually or in bulk.

In the backend, a new key `"history"` is added to the `data.json` which holds the array of history elements.

I made this mainly for myself, but maybe it's of use to someone else.
Let me know if there's any changes you'd like me to make. :)

![image](https://github.com/plugins-galore/obsidian-plugins-galore/assets/847687/bda80113-aea5-43dd-a14c-e36f39c55029)